### PR TITLE
feat: SSH鍵管理サービスの実装（iOS対応）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,12 @@
         "@capacitor/haptics": "7.0.1",
         "@capacitor/ios": "7.4.2",
         "@capacitor/keyboard": "7.0.1",
+        "@capacitor/preferences": "^7.0.1",
         "@capacitor/status-bar": "7.0.1",
         "@ionic/angular": "^8.0.0",
+        "@types/node-forge": "^1.3.13",
         "ionicons": "^7.0.0",
+        "node-forge": "^1.3.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -2731,6 +2734,15 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-7.0.1.tgz",
       "integrity": "sha512-Gi064vOARMac+x9/DmEFeywN9oAETMf3OYsMuYm9gA8SvdsDJ3QJqMoFnSEIORYXe21Jzt2SIEdLlpT65P/b2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capacitor/preferences": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/preferences/-/preferences-7.0.1.tgz",
+      "integrity": "sha512-XF9jOHzvoIBZLwZr/EX6aVaUO1d8Mx7TwBLQS33pYHOliCW5knT5KUkFOXNNYxh9qqODYesee9xuQIKNJpQBag==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=7.0.0"
@@ -6307,7 +6319,6 @@
       "version": "24.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
       "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
@@ -6317,7 +6328,6 @@
       "version": "1.3.13",
       "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.13.tgz",
       "integrity": "sha512-zePQJSW5QkwSHKRApqWCVKeKoSOt4xvEnLENZPjyvm9Ezdf/EyDeJM7jqLzOwjVICQQzvLZ63T55MKdJB5H6ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -13783,7 +13793,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-      "dev": true,
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -17600,7 +17609,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,12 @@
     "@capacitor/haptics": "7.0.1",
     "@capacitor/ios": "7.4.2",
     "@capacitor/keyboard": "7.0.1",
+    "@capacitor/preferences": "^7.0.1",
     "@capacitor/status-bar": "7.0.1",
     "@ionic/angular": "^8.0.0",
+    "@types/node-forge": "^1.3.13",
     "ionicons": "^7.0.0",
+    "node-forge": "^1.3.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/src/app/core/services/index.ts
+++ b/src/app/core/services/index.ts
@@ -1,0 +1,2 @@
+export { KeyManagerService } from './key-manager.service';
+export { KeyPair } from './key-pair.interface';

--- a/src/app/core/services/key-manager.service.spec.ts
+++ b/src/app/core/services/key-manager.service.spec.ts
@@ -1,0 +1,125 @@
+import { TestBed } from '@angular/core/testing';
+import { KeyManagerService } from './key-manager.service';
+
+describe('KeyManagerService', () => {
+  let service: KeyManagerService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(KeyManagerService);
+  });
+
+  it('サービスが作成されること', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('generateKeyPair', () => {
+    it('RSA 4096bitの鍵ペアを生成すること', async () => {
+      const keyPair = await service.generateKeyPair('test-key');
+
+      expect(keyPair).toBeDefined();
+      expect(keyPair.publicKey).toBeDefined();
+      expect(keyPair.privateKey).toBeDefined();
+      expect(keyPair.name).toBe('test-key');
+      expect(keyPair.fingerprint).toBeDefined();
+    });
+
+    it('公開鍵がOpenSSH形式であること', async () => {
+      const keyPair = await service.generateKeyPair('test-key');
+
+      expect(keyPair.publicKey).toMatch(/^ssh-rsa\s+[A-Za-z0-9+/]+=*\s+.*$/);
+    });
+  });
+
+  describe('saveKey', () => {
+    it('鍵をKeychainに保存できること', async () => {
+      const keyPair = await service.generateKeyPair('test-key');
+      const result = await service.saveKey(keyPair);
+
+      expect(result).toBe(true);
+    });
+
+    it('同じ名前の鍵を保存しようとするとエラーになること', async () => {
+      const keyPair1 = await service.generateKeyPair('duplicate-key');
+      await service.saveKey(keyPair1);
+
+      const keyPair2 = await service.generateKeyPair('duplicate-key');
+      await expectAsync(service.saveKey(keyPair2)).toBeRejectedWithError(
+        'Key with this name already exists'
+      );
+    });
+  });
+
+  describe('getKey', () => {
+    it('保存した鍵を取得できること', async () => {
+      const originalKeyPair = await service.generateKeyPair('get-test-key');
+      await service.saveKey(originalKeyPair);
+
+      const retrievedKey = await service.getKey('get-test-key');
+
+      expect(retrievedKey).toBeDefined();
+      expect(retrievedKey).not.toBeNull();
+      expect(retrievedKey!.name).toBe('get-test-key');
+      expect(retrievedKey!.privateKey).toBe(originalKeyPair.privateKey);
+    });
+
+    it('存在しない鍵を取得しようとするとnullを返すこと', async () => {
+      const result = await service.getKey('non-existent-key');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getAllKeys', () => {
+    it('すべての鍵の一覧を取得できること', async () => {
+      // テスト前にクリア
+      const existingKeys = await service.getAllKeys();
+      for (const key of existingKeys) {
+        await service.deleteKey(key.name);
+      }
+
+      const keyPair1 = await service.generateKeyPair('key1');
+      const keyPair2 = await service.generateKeyPair('key2');
+      await service.saveKey(keyPair1);
+      await service.saveKey(keyPair2);
+
+      const keys = await service.getAllKeys();
+
+      expect(keys.length).toBe(2);
+      expect(keys.map(k => k.name)).toContain('key1');
+      expect(keys.map(k => k.name)).toContain('key2');
+    });
+
+    it('鍵が存在しない場合は空配列を返すこと', async () => {
+      // すべての鍵を削除
+      const existingKeys = await service.getAllKeys();
+      for (const key of existingKeys) {
+        await service.deleteKey(key.name);
+      }
+
+      const keys = await service.getAllKeys();
+
+      expect(keys).toEqual([]);
+    });
+  });
+
+  describe('deleteKey', () => {
+    it('鍵を削除できること', async () => {
+      const keyPair = await service.generateKeyPair('delete-test-key');
+      await service.saveKey(keyPair);
+
+      const result = await service.deleteKey('delete-test-key');
+
+      expect(result).toBe(true);
+
+      const retrievedKey = await service.getKey('delete-test-key');
+      expect(retrievedKey).toBeNull();
+    });
+
+    it('存在しない鍵を削除しようとするとfalseを返すこと', async () => {
+      const result = await service.deleteKey('non-existent-key');
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/app/core/services/key-manager.service.ts
+++ b/src/app/core/services/key-manager.service.ts
@@ -1,0 +1,163 @@
+import { Injectable } from '@angular/core';
+import { Capacitor } from '@capacitor/core';
+import { KeyPair } from './key-pair.interface';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class KeyManagerService {
+  private readonly keyPrefix = 'ssh_key_';
+  private readonly platform = Capacitor.getPlatform();
+
+  constructor() {}
+
+  async generateKeyPair(name: string): Promise<KeyPair> {
+    // 実際の実装では node-forge を使用しますが、
+    // まずはモックデータで実装します
+    const mockPrivateKey = this.generateMockPrivateKey();
+    const mockPublicKey = this.generateMockPublicKey();
+
+    return {
+      name,
+      privateKey: mockPrivateKey,
+      publicKey: mockPublicKey,
+      fingerprint: this.generateFingerprint(mockPublicKey),
+      createdAt: new Date(),
+    };
+  }
+
+  async saveKey(keyPair: KeyPair): Promise<boolean> {
+    try {
+      // 既存の鍵をチェック
+      const existingKey = await this.getKey(keyPair.name);
+      if (existingKey) {
+        throw new Error('Key with this name already exists');
+      }
+
+      if (this.platform === 'ios') {
+        // iOSの場合はKeychainに保存（後で実装）
+        await this.saveToKeychain(keyPair);
+      } else {
+        // Web版のフォールバック
+        await this.saveToLocalStorage(keyPair);
+      }
+
+      return true;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async getKey(name: string): Promise<KeyPair | null> {
+    try {
+      if (this.platform === 'ios') {
+        return await this.getFromKeychain(name);
+      } else {
+        return await this.getFromLocalStorage(name);
+      }
+    } catch (error) {
+      return null;
+    }
+  }
+
+  async getAllKeys(): Promise<KeyPair[]> {
+    if (this.platform === 'ios') {
+      return await this.getAllFromKeychain();
+    } else {
+      return await this.getAllFromLocalStorage();
+    }
+  }
+
+  async deleteKey(name: string): Promise<boolean> {
+    try {
+      const key = await this.getKey(name);
+      if (!key) {
+        return false;
+      }
+
+      if (this.platform === 'ios') {
+        await this.deleteFromKeychain(name);
+      } else {
+        await this.deleteFromLocalStorage(name);
+      }
+
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  // Private methods for iOS Keychain
+  private async saveToKeychain(keyPair: KeyPair): Promise<void> {
+    // TODO: 実際のKeychainアクセスはCapacitorプラグインが必要
+    // 現在はLocalStorageで代用
+    await this.saveToLocalStorage(keyPair);
+  }
+
+  private async getFromKeychain(name: string): Promise<KeyPair | null> {
+    // TODO: 実際のKeychainアクセスはCapacitorプラグインが必要
+    return await this.getFromLocalStorage(name);
+  }
+
+  private async getAllFromKeychain(): Promise<KeyPair[]> {
+    // TODO: 実際のKeychainアクセスはCapacitorプラグインが必要
+    return await this.getAllFromLocalStorage();
+  }
+
+  private async deleteFromKeychain(name: string): Promise<void> {
+    // TODO: 実際のKeychainアクセスはCapacitorプラグインが必要
+    await this.deleteFromLocalStorage(name);
+  }
+
+  // Private methods for LocalStorage (Web fallback)
+  private async saveToLocalStorage(keyPair: KeyPair): Promise<void> {
+    const keys = await this.getAllFromLocalStorage();
+    keys.push(keyPair);
+    localStorage.setItem(this.keyPrefix + 'list', JSON.stringify(keys));
+  }
+
+  private async getFromLocalStorage(name: string): Promise<KeyPair | null> {
+    const keys = await this.getAllFromLocalStorage();
+    return keys.find(k => k.name === name) || null;
+  }
+
+  private async getAllFromLocalStorage(): Promise<KeyPair[]> {
+    const keysJson = localStorage.getItem(this.keyPrefix + 'list');
+    if (!keysJson) {
+      return [];
+    }
+
+    try {
+      return JSON.parse(keysJson);
+    } catch {
+      return [];
+    }
+  }
+
+  private async deleteFromLocalStorage(name: string): Promise<void> {
+    const keys = await this.getAllFromLocalStorage();
+    const filteredKeys = keys.filter(k => k.name !== name);
+    localStorage.setItem(this.keyPrefix + 'list', JSON.stringify(filteredKeys));
+  }
+
+  // Mock data generators
+  private generateMockPrivateKey(): string {
+    return `-----BEGIN RSA PRIVATE KEY-----
+MIIJKQIBAAKCAgEA1234567890abcdefghijklmnopqrstuvwxyz...
+...mock private key content...
+-----END RSA PRIVATE KEY-----`;
+  }
+
+  private generateMockPublicKey(): string {
+    const mockKey =
+      'AAAAB3NzaC1yc2EAAAADAQABAAACAQDV' +
+      Math.random().toString(36).substring(2, 15);
+    return `ssh-rsa ${mockKey} claude-pal@ionic`;
+  }
+
+  private generateFingerprint(publicKey: string): string {
+    // 簡易的なフィンガープリント生成（実際はSHA256ハッシュを使用）
+    const hash = publicKey.split(' ')[1].substring(0, 16);
+    return `SHA256:${hash}`;
+  }
+}

--- a/src/app/core/services/key-pair.interface.ts
+++ b/src/app/core/services/key-pair.interface.ts
@@ -1,0 +1,7 @@
+export interface KeyPair {
+  name: string;
+  publicKey: string;
+  privateKey: string;
+  fingerprint: string;
+  createdAt: Date;
+}


### PR DESCRIPTION
## 概要
Phase 2: SSH鍵管理サービスの実装（iOS対応のみ）

## 実装内容

### ✅ 完了した機能
- **KeyManagerService** の作成（TDDで実装）
- **鍵ペアの生成機能**（現在はモック実装）
- **鍵の保存・取得機能**（iOS Keychainは後日実装予定、現在はLocalStorage使用）
- **鍵の一覧表示・削除機能**
- **単体テストの作成**（全機能をカバー）

### 📝 実装詳細
- TypeScriptの型安全性を保持
- Capacitorを使用したプラットフォーム判定
- シンプルなインターフェース設計
```typescript
interface KeyPair {
  name: string;
  publicKey: string;
  privateKey: string;
  fingerprint: string;
  createdAt: Date;
}
```

### 🔨 今後の実装予定
- 実際のRSA 4096bit鍵生成（node-forgeまたはWebCrypto API）
- iOS Keychainへの実際の保存（Capacitorプラグイン開発）
- 生体認証（Touch ID/Face ID）の統合

### ✅ チェック項目
- ✅ ESLint: すべてのファイルがリンティングをパス
- ✅ Prettier: コードフォーマット済み
- ✅ Build: ビルド成功
- ✅ Pre-push hooks: すべてのチェックをパス

### 📦 追加した依存関係
- `@capacitor/preferences`: Capacitorの設定管理用
- `node-forge`: RSA鍵生成用（将来的な実装のため）
- `@types/node-forge`: TypeScript型定義

🤖 Generated with [Claude Code](https://claude.ai/code)