### PR TITLE
feat: iOS専用SSH Pluginの実装

### DIFF
--- a/.claude/plan/02_implementation_todo.md
+++ b/.claude/plan/02_implementation_todo.md
@@ -111,18 +111,18 @@
 ## Phase 3: iOS専用バックエンド機能実装（最優先）
 
 ### Capacitor SSH Plugin開発（iOS専用）
-- [ ] **カスタムCapacitorプラグインの作成**
-  - [ ] `npm init @capacitor/plugin claude-pal-ssh`でプラグイン雛形作成
-  - [ ] iOS専用プラグインとして設定（Android除外）
-  - [ ] Swift 5.0以上での実装準備
+- [x] **カスタムCapacitorプラグインの作成**
+  - [x] ~~`npm init @capacitor/plugin claude-pal-ssh`でプラグイン雛形作成~~ プロジェクト内に直接実装
+  - [x] iOS専用プラグインとして設定（Android除外）
+  - [x] Swift 5.0以上での実装準備
 - [ ] **iOSネイティブSSHライブラリの統合**
   - [ ] NMSSH（libssh2ベース）の採用検討
   - [ ] CocoaPodsでの依存関係設定
   - [ ] Swiftブリッジングヘッダーの設定
-- [ ] **プラグインAPIの設計**
-  - [ ] TypeScript定義ファイルの作成
-  - [ ] iOS実装とのインターフェース定義
-  - [ ] エラーハンドリング設計
+- [x] **プラグインAPIの設計**
+  - [x] TypeScript定義ファイルの作成（ssh-plugin.ts）
+  - [x] iOS実装とのインターフェース定義（SSHPlugin.swift, SSHPlugin.m）
+  - [x] エラーハンドリング設計
 
 ### iOS SSH実装（Swift）
 - [ ] **SSH接続機能の実装**
@@ -143,10 +143,10 @@
   - [ ] バッファ管理とフロー制御
 
 ### Capacitorブリッジ実装
-- [ ] **JavaScript⇔Native通信**
-  - [ ] Capacitorプラグインメソッドの実装
-  - [ ] イベントリスナー（データ受信、状態変更）
-  - [ ] Promise/Callbackパターンの実装
+- [x] **JavaScript⇔Native通信**
+  - [x] Capacitorプラグインメソッドの実装（connect, sendCommand, resizeWindow, disconnect）
+  - [x] イベントリスナー（データ受信、状態変更）
+  - [x] Promise/Callbackパターンの実装
 - [ ] **xterm.js統合**
   - [ ] TerminalサービスでのPlugin使用
   - [ ] データストリームのxterm.write()への接続
@@ -165,13 +165,17 @@
 
 ## Phase 4: UIコンポーネント実装
 
-### デモUI実装（Tab1）
-- [x] SSH鍵管理デモ画面の作成
+### デモUI実装（Tab1, Tab3）
+- [x] SSH鍵管理デモ画面の作成（Tab1）
 - [x] 鍵生成フォームの実装
 - [x] 鍵一覧表示の実装
 - [x] 鍵詳細表示機能
 - [x] 公開鍵コピー機能
 - [x] 鍵削除機能（確認ダイアログ付き）
+- [x] SSH接続デモ画面の作成（Tab3）
+  - [x] 接続フォーム（ホスト、ポート、ユーザー名、認証方法）
+  - [x] ターミナルコンポーネントとの統合
+  - [x] 接続/切断機能
 
 ### ターミナルコンポーネント
 - [x] `terminal.component.ts`の作成

--- a/.claude/plan/02_implementation_todo.md
+++ b/.claude/plan/02_implementation_todo.md
@@ -115,14 +115,20 @@
   - [x] ~~`npm init @capacitor/plugin claude-pal-ssh`でプラグイン雛形作成~~ プロジェクト内に直接実装
   - [x] iOS専用プラグインとして設定（Android除外）
   - [x] Swift 5.0以上での実装準備
-- [ ] **iOSネイティブSSHライブラリの統合**
-  - [ ] NMSSH（libssh2ベース）の採用検討
-  - [ ] CocoaPodsでの依存関係設定
-  - [ ] Swiftブリッジングヘッダーの設定
 - [x] **プラグインAPIの設計**
   - [x] TypeScript定義ファイルの作成（ssh-plugin.ts）
   - [x] iOS実装とのインターフェース定義（SSHPlugin.swift, SSHPlugin.m）
   - [x] エラーハンドリング設計
+- [x] **モック実装**
+  - [x] iOSプラグインのモック実装（SSHPlugin.swift）
+  - [x] 接続/切断のシミュレーション
+  - [x] データ送受信のモック
+
+### iOSネイティブSSHライブラリの統合
+- [ ] **NMSSHライブラリの統合**
+  - [ ] NMSSH（libssh2ベース）の採用検討
+  - [ ] CocoaPodsでの依存関係設定
+  - [ ] Swiftブリッジングヘッダーの設定
 
 ### iOS SSH実装（Swift）
 - [ ] **SSH接続機能の実装**
@@ -147,11 +153,11 @@
   - [x] Capacitorプラグインメソッドの実装（connect, sendCommand, resizeWindow, disconnect）
   - [x] イベントリスナー（データ受信、状態変更）
   - [x] Promise/Callbackパターンの実装
-- [ ] **xterm.js統合**
-  - [ ] TerminalサービスでのPlugin使用
-  - [ ] データストリームのxterm.write()への接続
-  - [ ] キーボード入力のPlugin送信
-  - [ ] ウィンドウサイズ変更の同期
+- [x] **xterm.js統合（UI側）**
+  - [x] Tab3でのPlugin使用
+  - [x] データストリームのxterm.write()への接続
+  - [x] キーボード入力のPlugin送信
+  - [x] ウィンドウサイズ変更の同期
 
 ### iOS固有機能の活用
 - [ ] **Keychainとの統合**

--- a/ios/App/App/SSHPlugin.m
+++ b/ios/App/App/SSHPlugin.m
@@ -1,0 +1,8 @@
+#import <Capacitor/Capacitor.h>
+
+CAP_PLUGIN(SSHPlugin, "SSH",
+    CAP_PLUGIN_METHOD(connect, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(sendCommand, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(resizeWindow, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(disconnect, CAPPluginReturnPromise);
+)

--- a/ios/App/App/SSHPlugin.swift
+++ b/ios/App/App/SSHPlugin.swift
@@ -1,0 +1,297 @@
+import Capacitor
+import Foundation
+
+/**
+ * SSH接続を管理するCapacitorプラグイン
+ * 
+ * このプラグインはiOS専用で、NMSSH（将来的に統合予定）を使用して
+ * SSH接続を確立し、ターミナルセッションを管理します。
+ */
+@objc(SSHPlugin)
+public class SSHPlugin: CAPPlugin {
+    /**
+     * アクティブなSSHセッションを管理するディクショナリ
+     * キー: セッションID、値: SSHSessionオブジェクト
+     */
+    private var sessions: [String: SSHSession] = [:]
+    
+    /**
+     * SSH接続を確立する
+     * 
+     * @param call Capacitorプラグインコール
+     */
+    @objc func connect(_ call: CAPPluginCall) {
+        // 必須パラメータの取得
+        guard let host = call.getString("host"),
+              let username = call.getString("username"),
+              let port = call.getInt("port") else {
+            call.reject("必須パラメータが不足しています: host, username, port")
+            return
+        }
+        
+        // バックグラウンドスレッドで接続処理を実行
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                // セッションIDを生成
+                let sessionId = UUID().uuidString
+                
+                // セッションオブジェクトを作成
+                let session = SSHSession(
+                    id: sessionId,
+                    host: host,
+                    port: port,
+                    username: username
+                )
+                
+                // 認証情報の設定
+                if let password = call.getString("password") {
+                    session.authType = .password(password)
+                } else if let privateKey = call.getString("privateKey") {
+                    let passphrase = call.getString("passphrase")
+                    session.authType = .privateKey(key: privateKey, passphrase: passphrase)
+                } else {
+                    throw SSHError.missingAuthCredentials
+                }
+                
+                // TODO: 実際のSSH接続実装（NMSSH統合後）
+                // 現在はモック実装
+                self.mockConnect(session: session)
+                
+                // セッションを保存
+                self.sessions[sessionId] = session
+                
+                // 接続成功を通知
+                DispatchQueue.main.async {
+                    self.notifyListeners("connectionStateChanged", data: [
+                        "sessionId": sessionId,
+                        "state": "connected"
+                    ])
+                    
+                    call.resolve([
+                        "sessionId": sessionId
+                    ])
+                }
+                
+            } catch {
+                DispatchQueue.main.async {
+                    self.notifyListeners("connectionStateChanged", data: [
+                        "state": "error",
+                        "error": error.localizedDescription
+                    ])
+                    
+                    call.reject("接続に失敗しました", error.localizedDescription)
+                }
+            }
+        }
+    }
+    
+    /**
+     * コマンドを送信する
+     * 
+     * @param call Capacitorプラグインコール
+     */
+    @objc func sendCommand(_ call: CAPPluginCall) {
+        guard let sessionId = call.getString("sessionId"),
+              let command = call.getString("command") else {
+            call.reject("必須パラメータが不足しています: sessionId, command")
+            return
+        }
+        
+        guard let session = sessions[sessionId] else {
+            call.reject("無効なセッションID")
+            return
+        }
+        
+        // TODO: 実際のコマンド送信実装
+        mockSendCommand(session: session, command: command)
+        
+        call.resolve()
+    }
+    
+    /**
+     * ウィンドウサイズを変更する
+     * 
+     * @param call Capacitorプラグインコール
+     */
+    @objc func resizeWindow(_ call: CAPPluginCall) {
+        guard let sessionId = call.getString("sessionId"),
+              let cols = call.getInt("cols"),
+              let rows = call.getInt("rows") else {
+            call.reject("必須パラメータが不足しています: sessionId, cols, rows")
+            return
+        }
+        
+        guard let session = sessions[sessionId] else {
+            call.reject("無効なセッションID")
+            return
+        }
+        
+        session.cols = cols
+        session.rows = rows
+        
+        // TODO: 実際のPTYリサイズ実装
+        
+        call.resolve()
+    }
+    
+    /**
+     * 接続を切断する
+     * 
+     * @param call Capacitorプラグインコール
+     */
+    @objc func disconnect(_ call: CAPPluginCall) {
+        guard let sessionId = call.getString("sessionId") else {
+            call.reject("sessionIdが必要です")
+            return
+        }
+        
+        guard let session = sessions[sessionId] else {
+            call.reject("無効なセッションID")
+            return
+        }
+        
+        // TODO: 実際の切断処理
+        
+        // セッションを削除
+        sessions.removeValue(forKey: sessionId)
+        
+        // 切断を通知
+        self.notifyListeners("connectionStateChanged", data: [
+            "sessionId": sessionId,
+            "state": "disconnected"
+        ])
+        
+        call.resolve()
+    }
+    
+    // MARK: - モック実装（開発用）
+    
+    private func mockConnect(session: SSHSession) {
+        // 接続のシミュレーション
+        Thread.sleep(forTimeInterval: 0.5)
+        
+        print("Mock SSH connection established:")
+        print("  Host: \(session.host):\(session.port)")
+        print("  Username: \(session.username)")
+        print("  Auth: \(session.authType)")
+        
+        // モックデータストリームを開始
+        startMockDataStream(session: session)
+    }
+    
+    private func mockSendCommand(session: SSHSession, command: String) {
+        // コマンドのエコーバック
+        self.notifyListeners("dataReceived", data: [
+            "sessionId": session.id,
+            "data": command
+        ])
+        
+        // Enterキーが含まれている場合
+        if command.contains("\n") || command.contains("\r") {
+            // モックレスポンスを生成
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                let response = self.generateMockResponse(for: command.trimmingCharacters(in: .whitespacesAndNewlines))
+                self.notifyListeners("dataReceived", data: [
+                    "sessionId": session.id,
+                    "data": "\r\n\(response)\r\n$ "
+                ])
+            }
+        }
+    }
+    
+    private func startMockDataStream(session: SSHSession) {
+        // 初期プロンプトを送信
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            self.notifyListeners("dataReceived", data: [
+                "sessionId": session.id,
+                "data": "Welcome to Mock SSH Server\r\n\r\n$ "
+            ])
+        }
+    }
+    
+    private func generateMockResponse(for command: String) -> String {
+        switch command {
+        case "ls":
+            return "Applications\nDesktop\nDocuments\nDownloads"
+        case "pwd":
+            return "/Users/mockuser"
+        case "whoami":
+            return "mockuser"
+        case "date":
+            return Date().description
+        case let cmd where cmd.starts(with: "echo "):
+            return String(cmd.dropFirst(5))
+        default:
+            return "mock: \(command): command not found"
+        }
+    }
+}
+
+// MARK: - SSHSession
+
+/**
+ * SSHセッションを表すクラス
+ */
+class SSHSession {
+    let id: String
+    let host: String
+    let port: Int
+    let username: String
+    var authType: AuthType = .none
+    var rows: Int = 24
+    var cols: Int = 80
+    
+    init(id: String, host: String, port: Int, username: String) {
+        self.id = id
+        self.host = host
+        self.port = port
+        self.username = username
+    }
+}
+
+// MARK: - AuthType
+
+/**
+ * SSH認証タイプ
+ */
+enum AuthType: CustomStringConvertible {
+    case none
+    case password(String)
+    case privateKey(key: String, passphrase: String?)
+    
+    var description: String {
+        switch self {
+        case .none:
+            return "none"
+        case .password:
+            return "password"
+        case .privateKey:
+            return "privateKey"
+        }
+    }
+}
+
+// MARK: - SSHError
+
+/**
+ * SSHエラー
+ */
+enum SSHError: LocalizedError {
+    case missingAuthCredentials
+    case connectionFailed(String)
+    case authenticationFailed
+    case sessionNotFound
+    
+    var errorDescription: String? {
+        switch self {
+        case .missingAuthCredentials:
+            return "認証情報が提供されていません"
+        case .connectionFailed(let reason):
+            return "接続に失敗しました: \(reason)"
+        case .authenticationFailed:
+            return "認証に失敗しました"
+        case .sessionNotFound:
+            return "セッションが見つかりません"
+        }
+    }
+}

--- a/src/app/core/plugins/ssh-plugin.ts
+++ b/src/app/core/plugins/ssh-plugin.ts
@@ -1,0 +1,88 @@
+import { registerPlugin } from '@capacitor/core';
+import type { PluginListenerHandle } from '@capacitor/core';
+
+/**
+ * SSH接続オプション
+ * @interface SSHConnectionOptions
+ */
+export interface SSHConnectionOptions {
+  /** 接続先のホスト名またはIPアドレス */
+  host: string;
+  /** SSHポート番号（デフォルト: 22） */
+  port: number;
+  /** ユーザー名 */
+  username: string;
+  /** パスワード（パスワード認証の場合） */
+  password?: string;
+  /** 秘密鍵（鍵認証の場合） */
+  privateKey?: string;
+  /** パスフレーズ（秘密鍵が暗号化されている場合） */
+  passphrase?: string;
+}
+
+/**
+ * SSHプラグインのインターフェース
+ * @interface SSHPlugin
+ */
+export interface SSHPlugin {
+  /**
+   * SSH接続を確立する
+   * @param options 接続オプション
+   * @returns 接続成功時にセッションID
+   */
+  connect(options: SSHConnectionOptions): Promise<{ sessionId: string }>;
+
+  /**
+   * コマンドを送信する
+   * @param options セッションIDとコマンド
+   */
+  sendCommand(options: { sessionId: string; command: string }): Promise<void>;
+
+  /**
+   * ウィンドウサイズを変更する
+   * @param options セッションID、列数、行数
+   */
+  resizeWindow(options: {
+    sessionId: string;
+    cols: number;
+    rows: number;
+  }): Promise<void>;
+
+  /**
+   * 接続を切断する
+   * @param options セッションID
+   */
+  disconnect(options: { sessionId: string }): Promise<void>;
+
+  /**
+   * データ受信のリスナーを登録する
+   * @param eventName イベント名
+   * @param listenerFunc リスナー関数
+   */
+  addListener(
+    eventName: 'dataReceived',
+    listenerFunc: (data: { sessionId: string; data: string }) => void
+  ): Promise<PluginListenerHandle>;
+
+  /**
+   * 接続状態変更のリスナーを登録する
+   * @param eventName イベント名
+   * @param listenerFunc リスナー関数
+   */
+  addListener(
+    eventName: 'connectionStateChanged',
+    listenerFunc: (data: {
+      sessionId: string;
+      state: 'connected' | 'disconnected' | 'error';
+      error?: string;
+    }) => void
+  ): Promise<PluginListenerHandle>;
+
+  /**
+   * リスナーを削除する
+   * @param listenerHandle リスナーハンドル
+   */
+  removeAllListeners(): Promise<void>;
+}
+
+export const SSH = registerPlugin<SSHPlugin>('SSH');

--- a/src/app/tab3/tab3.page.html
+++ b/src/app/tab3/tab3.page.html
@@ -1,17 +1,20 @@
 <ion-header [translucent]="true">
   <ion-toolbar>
-    <ion-title>メッセージコンポーネント動作確認</ion-title>
+    <ion-title>テスト機能</ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content [fullscreen]="true">
   <ion-header collapse="condense">
     <ion-toolbar>
-      <ion-title size="large">メッセージデモ</ion-title>
+      <ion-title size="large">テスト機能</ion-title>
     </ion-toolbar>
   </ion-header>
 
   <ion-segment [(ngModel)]="selectedTab" mode="md">
+    <ion-segment-button value="ssh">
+      <ion-label>SSH接続</ion-label>
+    </ion-segment-button>
     <ion-segment-button value="messages">
       <ion-label>メッセージ</ion-label>
     </ion-segment-button>
@@ -25,9 +28,117 @@
       <ion-label>暗号化</ion-label>
     </ion-segment-button>
     <ion-segment-button value="migration">
-      <ion-label>マイグレーション</ion-label>
+      <ion-label>移行</ion-label>
     </ion-segment-button>
   </ion-segment>
+
+  <!-- SSH接続テスト -->
+  <div *ngIf="selectedTab === 'ssh'">
+    <ion-card *ngIf="!isConnected">
+      <ion-card-header>
+        <ion-card-title>SSH接続設定</ion-card-title>
+      </ion-card-header>
+      <ion-card-content>
+        <ion-item>
+          <ion-label position="floating">ホスト</ion-label>
+          <ion-input
+            [(ngModel)]="connectionForm.host"
+            type="text"
+            placeholder="192.168.1.100"
+          >
+          </ion-input>
+        </ion-item>
+
+        <ion-item>
+          <ion-label position="floating">ポート</ion-label>
+          <ion-input
+            [(ngModel)]="connectionForm.port"
+            type="number"
+            placeholder="22"
+          >
+          </ion-input>
+        </ion-item>
+
+        <ion-item>
+          <ion-label position="floating">ユーザー名</ion-label>
+          <ion-input
+            [(ngModel)]="connectionForm.username"
+            type="text"
+            placeholder="user"
+          >
+          </ion-input>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>認証方法</ion-label>
+          <ion-select [(ngModel)]="connectionForm.authType">
+            <ion-select-option value="password">パスワード</ion-select-option>
+            <ion-select-option value="key">SSH鍵</ion-select-option>
+          </ion-select>
+        </ion-item>
+
+        <ion-item *ngIf="connectionForm.authType === 'password'">
+          <ion-label position="floating">パスワード</ion-label>
+          <ion-input [(ngModel)]="connectionForm.password" type="password">
+          </ion-input>
+        </ion-item>
+
+        <div *ngIf="connectionForm.authType === 'key'">
+          <ion-item>
+            <ion-label position="floating">SSH秘密鍵</ion-label>
+            <ion-textarea
+              [(ngModel)]="connectionForm.privateKey"
+              rows="5"
+              placeholder="-----BEGIN OPENSSH PRIVATE KEY-----"
+            >
+            </ion-textarea>
+          </ion-item>
+
+          <ion-item>
+            <ion-label position="floating"
+              >パスフレーズ（オプション）</ion-label
+            >
+            <ion-input [(ngModel)]="connectionForm.passphrase" type="password">
+            </ion-input>
+          </ion-item>
+        </div>
+
+        <ion-button
+          expand="block"
+          (click)="connectSSH()"
+          class="ion-margin-top"
+        >
+          <ion-icon name="terminal" slot="start"></ion-icon>
+          接続
+        </ion-button>
+      </ion-card-content>
+    </ion-card>
+
+    <ion-card *ngIf="isConnected">
+      <ion-card-header>
+        <ion-card-title>
+          SSH接続中
+          <ion-button
+            fill="clear"
+            size="small"
+            (click)="disconnectSSH()"
+            color="danger"
+            class="ion-float-right"
+          >
+            <ion-icon name="close" slot="icon-only"></ion-icon>
+          </ion-button>
+        </ion-card-title>
+      </ion-card-header>
+      <ion-card-content>
+        <app-terminal
+          (terminalData)="onTerminalData($event)"
+          (terminalResize)="onTerminalResize($event)"
+          [options]="{ fontSize: 14 }"
+        >
+        </app-terminal>
+      </ion-card-content>
+    </ion-card>
+  </div>
 
   <div *ngIf="selectedTab === 'messages'">
     <ion-card>
@@ -192,18 +303,11 @@
           </ion-item>
           <ion-item>
             <ion-label>
-              <h2>ターミナル設定</h2>
-              <p>フォントサイズ: {{ settings.terminalSettings.fontSize }}px</p>
-              <p>フォント: {{ settings.terminalSettings.fontFamily }}</p>
-              <p>カーソル: {{ settings.terminalSettings.cursorStyle }}</p>
-            </ion-label>
-          </ion-item>
-          <ion-item>
-            <ion-label>
-              <h2>接続設定</h2>
-              <p>タイムアウト: {{ settings.connectionSettings.timeout }}秒</p>
+              <h2>アプリ設定</h2>
+              <p>テーマ: {{ settings.theme }}</p>
               <p>
-                デフォルトポート: {{ settings.connectionSettings.defaultPort }}
+                生体認証: {{ settings.security.biometricAuthEnabled ? '有効' :
+                '無効' }}
               </p>
             </ion-label>
           </ion-item>

--- a/src/app/tab3/tab3.page.ts
+++ b/src/app/tab3/tab3.page.ts
@@ -539,15 +539,22 @@ print(fibonacci(10))  # 55
   }
 
   private async setupListeners() {
-    this.dataListener = await SSH.addListener('dataReceived', data => {
-      if (data.sessionId === this.sessionId && this.terminalComponent) {
-        this.terminalComponent.write(data.data);
+    this.dataListener = await SSH.addListener(
+      'dataReceived',
+      (data: { sessionId: string; data: string }) => {
+        if (data.sessionId === this.sessionId && this.terminalComponent) {
+          this.terminalComponent.write(data.data);
+        }
       }
-    });
+    );
 
     this.stateListener = await SSH.addListener(
       'connectionStateChanged',
-      async data => {
+      async (data: {
+        sessionId: string;
+        state: 'connected' | 'disconnected' | 'error';
+        error?: string;
+      }) => {
         if (data.state === 'disconnected') {
           this.sessionId = null;
           this.isConnected = false;
@@ -576,7 +583,7 @@ print(fibonacci(10))  # 55
   onTerminalData(data: string) {
     if (this.sessionId) {
       SSH.sendCommand({ sessionId: this.sessionId, command: data }).catch(
-        error => {
+        (error: Error) => {
           console.error('コマンド送信エラー:', error);
         }
       );
@@ -589,7 +596,7 @@ print(fibonacci(10))  # 55
         sessionId: this.sessionId,
         cols: event.cols,
         rows: event.rows,
-      }).catch(error => {
+      }).catch((error: Error) => {
         console.error('リサイズエラー:', error);
       });
     }


### PR DESCRIPTION
## 概要
Phase 3「Capacitor SSH Plugin開発（iOS専用）」の実装です。

## 変更内容
- iOS向けCapacitorプラグインの実装（モック版）
  - SSHPlugin.swift: ネイティブプラグイン実装
  - SSHPlugin.m: Objective-Cブリッジファイル
  - ssh-plugin.ts: TypeScript側のプラグイン定義
- SSH接続テスト用UIの追加（tab3ページ）
  - 接続フォーム（ホスト、ポート、ユーザー名、認証方法）
  - ターミナルコンポーネントとの統合
  - リアルタイムデータストリーミング

## テスト方法
1. `ionic serve`で開発サーバーを起動
2. Tab3の「SSH接続」セクションで接続設定を入力
3. 「接続」ボタンでモック接続を確立
4. ターミナルでのデータ送受信を確認

## 今後の予定
- NMSSHライブラリの統合による実際のSSH接続実装
- iOS実機でのテスト
- エラーハンドリングの強化

🤖 Generated with [Claude Code](https://claude.ai/code)